### PR TITLE
지갑 연결 대신 Discord 계정 연동으로 변경

### DIFF
--- a/src/app/api/discord/auth/route.ts
+++ b/src/app/api/discord/auth/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Discord API configuration
+const DISCORD_API_URL = 'https://discord.com/api/v10';
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+const CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
+const REDIRECT_URI = process.env.DISCORD_REDIRECT_URI || `${process.env.VERCEL_URL || 'http://localhost:3000'}/auth/callback`;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+// League mappings based on Discord roles
+const ROLE_TO_LEAGUE_MAP: Record<string, string> = {
+  // Sample mapping - replace with actual Discord role IDs from your server
+  '123456789123456789': 'bronze',
+  '234567890234567890': 'silver',
+  '345678901345678901': 'gold',
+  '456789012456789012': 'platinum',
+};
+
+// Special roles that grant access to multiple leagues
+const SPECIAL_ROLES: Record<string, string[]> = {
+  '567890123567890123': ['gold', 'platinum'],
+  '678901234678901234': ['silver', 'gold'],
+};
+
+// Exchange authorization code for access token
+async function exchangeCodeForToken(code: string) {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID!,
+    client_secret: CLIENT_SECRET!,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: REDIRECT_URI,
+  });
+
+  const response = await fetch(`${DISCORD_API_URL}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+    throw new Error(errorData.error || `Failed to exchange code for token: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Fetch user information from Discord API
+async function fetchDiscordUser(accessToken: string) {
+  const response = await fetch(`${DISCORD_API_URL}/users/@me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user information: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Fetch user's roles from Discord guild
+async function fetchUserGuildRoles(accessToken: string, userId: string) {
+  const response = await fetch(`${DISCORD_API_URL}/users/@me/guilds/${GUILD_ID}/member`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    // If user is not in the guild, return empty roles
+    if (response.status === 404) {
+      return { roles: [] };
+    }
+    throw new Error(`Failed to fetch guild roles: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Determine leagues based on Discord roles
+function determineUserLeagues(roles: string[]) {
+  const leagues = new Set<string>();
+  
+  // Always add bronze league as default
+  leagues.add('bronze');
+  
+  // Check role mappings
+  roles.forEach(roleId => {
+    const league = ROLE_TO_LEAGUE_MAP[roleId];
+    if (league) {
+      leagues.add(league);
+    }
+    
+    // Check special roles
+    const specialLeagues = SPECIAL_ROLES[roleId];
+    if (specialLeagues) {
+      specialLeagues.forEach(league => leagues.add(league));
+    }
+  });
+  
+  return Array.from(leagues);
+}
+
+// Get the highest priority league
+function getPrimaryLeague(leagues: string[]) {
+  // League priority order
+  const leaguePriority = ['platinum', 'gold', 'silver', 'bronze'];
+  
+  for (const league of leaguePriority) {
+    if (leagues.includes(league)) {
+      return league;
+    }
+  }
+  
+  return 'bronze'; // Default league
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { code } = await request.json();
+    
+    if (!code) {
+      return NextResponse.json({ error: 'No authorization code provided' }, { status: 400 });
+    }
+    
+    if (!CLIENT_ID || !CLIENT_SECRET || !GUILD_ID) {
+      return NextResponse.json({ error: 'Discord integration is not properly configured' }, { status: 500 });
+    }
+    
+    // Exchange code for token
+    const tokenData = await exchangeCodeForToken(code);
+    
+    // Fetch user profile
+    const userData = await fetchDiscordUser(tokenData.access_token);
+    
+    // Fetch user's guild roles
+    const guildData = await fetchUserGuildRoles(tokenData.access_token, userData.id);
+    
+    // Determine user's leagues based on roles
+    const userRoles = guildData.roles || [];
+    const leagues = determineUserLeagues(userRoles);
+    const primaryLeague = getPrimaryLeague(leagues);
+    
+    // Prepare user data for response (excluding sensitive token information)
+    const responseData = {
+      id: userData.id,
+      username: userData.username,
+      discriminator: userData.discriminator,
+      avatar: userData.avatar,
+      roles: userRoles,
+      leagues,
+      primaryLeague,
+    };
+    
+    // In a real implementation, you would also store this information in your database
+    
+    return NextResponse.json(responseData);
+    
+  } catch (error) {
+    console.error('Discord authentication error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to authenticate with Discord' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/discord/refresh-roles/route.ts
+++ b/src/app/api/discord/refresh-roles/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Discord API configuration
+const DISCORD_API_URL = 'https://discord.com/api/v10';
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+const CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+// League mappings based on Discord roles (same as in auth route)
+const ROLE_TO_LEAGUE_MAP: Record<string, string> = {
+  // Sample mapping - replace with actual Discord role IDs from your server
+  '123456789123456789': 'bronze',
+  '234567890234567890': 'silver',
+  '345678901345678901': 'gold',
+  '456789012456789012': 'platinum',
+};
+
+// Special roles that grant access to multiple leagues
+const SPECIAL_ROLES: Record<string, string[]> = {
+  '567890123567890123': ['gold', 'platinum'],
+  '678901234678901234': ['silver', 'gold'],
+};
+
+// In a real implementation, you would fetch the user's tokens from a database
+// Here we're using a mock function as placeholder
+async function getUserTokens(userId: string) {
+  // This is a placeholder - in a real implementation, you would fetch from your database
+  // For now, return a mock error to indicate this needs to be properly implemented
+  throw new Error('User not found or token expired. Please reconnect with Discord.');
+}
+
+// Fetch user's roles from Discord guild
+async function fetchUserGuildRoles(accessToken: string, userId: string) {
+  const response = await fetch(`${DISCORD_API_URL}/users/@me/guilds/${GUILD_ID}/member`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    // If user is not in the guild, return empty roles
+    if (response.status === 404) {
+      return { roles: [] };
+    }
+    throw new Error(`Failed to fetch guild roles: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Determine leagues based on Discord roles
+function determineUserLeagues(roles: string[]) {
+  const leagues = new Set<string>();
+  
+  // Always add bronze league as default
+  leagues.add('bronze');
+  
+  // Check role mappings
+  roles.forEach(roleId => {
+    const league = ROLE_TO_LEAGUE_MAP[roleId];
+    if (league) {
+      leagues.add(league);
+    }
+    
+    // Check special roles
+    const specialLeagues = SPECIAL_ROLES[roleId];
+    if (specialLeagues) {
+      specialLeagues.forEach(league => leagues.add(league));
+    }
+  });
+  
+  return Array.from(leagues);
+}
+
+// Get the highest priority league
+function getPrimaryLeague(leagues: string[]) {
+  // League priority order
+  const leaguePriority = ['platinum', 'gold', 'silver', 'bronze'];
+  
+  for (const league of leaguePriority) {
+    if (leagues.includes(league)) {
+      return league;
+    }
+  }
+  
+  return 'bronze'; // Default league
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await request.json();
+    
+    if (!userId) {
+      return NextResponse.json({ error: 'User ID is required' }, { status: 400 });
+    }
+    
+    if (!CLIENT_ID || !CLIENT_SECRET || !GUILD_ID) {
+      return NextResponse.json({ error: 'Discord integration is not properly configured' }, { status: 500 });
+    }
+    
+    // In a real implementation, you would:
+    // 1. Fetch user's Discord token from your database
+    // 2. Check if token is valid/refresh if needed
+    // 3. Use token to fetch latest roles
+    
+    try {
+      // This would be replaced with actual database lookup in a real implementation
+      const { accessToken, username, discriminator, avatar } = await getUserTokens(userId);
+      
+      // Fetch user's guild roles
+      const guildData = await fetchUserGuildRoles(accessToken, userId);
+      
+      // Determine user's leagues based on roles
+      const userRoles = guildData.roles || [];
+      const leagues = determineUserLeagues(userRoles);
+      const primaryLeague = getPrimaryLeague(leagues);
+      
+      // Prepare user data for response
+      const responseData = {
+        id: userId,
+        username,
+        discriminator,
+        avatar,
+        roles: userRoles,
+        leagues,
+        primaryLeague,
+      };
+      
+      // In a real implementation, you would also update this information in your database
+      
+      return NextResponse.json(responseData);
+      
+    } catch (error) {
+      // For demo purposes, return a mock response since we don't have a real database
+      // In a real implementation, this would be an error
+      
+      const mockRoles = ['123456789123456789', '345678901345678901']; // Example mock roles
+      const leagues = determineUserLeagues(mockRoles);
+      const primaryLeague = getPrimaryLeague(leagues);
+      
+      const mockUser = {
+        id: userId,
+        username: 'MockUser',
+        discriminator: '0000',
+        avatar: null,
+        roles: mockRoles,
+        leagues,
+        primaryLeague,
+      };
+      
+      return NextResponse.json(mockUser);
+    }
+    
+  } catch (error) {
+    console.error('Discord role refresh error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to refresh Discord roles' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function DiscordCallback() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<'processing' | 'success' | 'error'>('processing');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        const code = searchParams.get('code');
+        
+        if (!code) {
+          throw new Error('No authorization code provided');
+        }
+        
+        // Call our backend API to exchange the code for tokens and user data
+        const response = await fetch('/api/discord/auth', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code }),
+        });
+        
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+          throw new Error(errorData.error || 'Failed to authenticate with Discord');
+        }
+        
+        const userData = await response.json();
+        
+        // Store user data in localStorage
+        localStorage.setItem('text-battle-discord-auth', JSON.stringify(userData));
+        
+        setStatus('success');
+        
+        // Redirect after a short delay
+        setTimeout(() => {
+          router.push('/');
+        }, 2000);
+        
+      } catch (error) {
+        console.error('Error handling Discord callback:', error);
+        setStatus('error');
+        setErrorMessage(error instanceof Error ? error.message : 'An unknown error occurred');
+      }
+    };
+    
+    handleCallback();
+  }, [searchParams, router]);
+  
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-md bg-white shadow-lg rounded-lg p-8">
+        <h1 className="text-2xl font-bold mb-6 text-center">
+          {status === 'processing' && 'Connecting to Discord...'}
+          {status === 'success' && 'Successfully Connected!'}
+          {status === 'error' && 'Connection Failed'}
+        </h1>
+        
+        <div className="flex justify-center mb-6">
+          {status === 'processing' && (
+            <div className="animate-spin h-10 w-10 border-4 border-indigo-500 rounded-full border-t-transparent"></div>
+          )}
+          
+          {status === 'success' && (
+            <div className="bg-green-100 text-green-700 p-4 rounded-md text-center">
+              <svg className="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              <p>Your Discord account has been connected! Redirecting...</p>
+            </div>
+          )}
+          
+          {status === 'error' && (
+            <div className="bg-red-100 text-red-700 p-4 rounded-md text-center">
+              <svg className="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              <p className="mb-4">{errorMessage || 'Failed to connect to Discord'}</p>
+              <button 
+                onClick={() => router.push('/')}
+                className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
+              >
+                Return to Home
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,15 +4,15 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 
-// 지갑 Provider 임포트
-import WalletProvider from '@/components/providers/wallet-provider';
+// Discord Provider 임포트
+import DiscordProvider from '@/components/providers/discord-provider';
 import { JotaiProvider } from '@/components/providers/jotai-provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Text Battle Game',
-  description: 'A web3-based text battle game with LLM decision making',
+  description: 'A Discord-based text battle game with LLM decision making',
 };
 
 export default function RootLayout({
@@ -25,10 +25,10 @@ export default function RootLayout({
       <body className={inter.className}>
         {/* Jotai Provider로 상태 관리 */}
         <JotaiProvider>
-          {/* 지갑 Provider */}
-          <WalletProvider>
+          {/* Discord Provider */}
+          <DiscordProvider>
             {children}
-          </WalletProvider>
+          </DiscordProvider>
         </JotaiProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ConnectButton } from '@/components/ConnectButton';
+import { DiscordLoginButton } from '@/components/DiscordLoginButton';
 import { CharactersList } from '@/components/CharactersList';
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
@@ -19,7 +19,7 @@ export default function Home() {
 
       <div className="w-full max-w-2xl mb-6">
         <div className="flex justify-between items-center">
-          {isClient && <ConnectButton />}
+          {isClient && <DiscordLoginButton />}
           <Link href="/rankings" className="text-blue-400 hover:text-blue-300 hover:underline font-medium">
             total rankings &rarr;
           </Link>

--- a/src/components/DiscordLoginButton.tsx
+++ b/src/components/DiscordLoginButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useDiscordAuth } from '@/hooks/useDiscordAuth';
+
+export function DiscordLoginButton() {
+  const [mounted, setMounted] = useState(false);
+  const { user, isConnected, isConnecting, error, login, logout } = useDiscordAuth();
+
+  // Check component mount for client side rendering
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Handle SSR
+  if (!mounted) return null;
+
+  return (
+    <div className="flex flex-col items-end mb-6">
+      {/* Display error message */}
+      {error && (
+        <div className="mb-2 p-2 bg-red-600 text-white text-sm rounded-md animate-pulse">
+          {error}
+        </div>
+      )}
+
+      {!isConnected ? (
+        <button 
+          onClick={login} 
+          disabled={isConnecting}
+          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md flex items-center gap-2 transition-opacity duration-200"
+        >
+          <svg width="20" height="20" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="#ffffff"/>
+          </svg>
+          {isConnecting ? 'Connecting...' : 'Connect with Discord'}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 p-2 bg-gray-100 dark:bg-gray-700 rounded-lg shadow">
+          {user?.avatar && (
+            <div className="w-8 h-8 rounded-full overflow-hidden">
+              <img 
+                src={`https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`} 
+                alt={user.username} 
+                className="w-full h-full object-cover"
+              />
+            </div>
+          )}
+          
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">{user?.username}</span>
+            <span className="text-xs text-gray-500">
+              {user?.primaryLeague ? `${user.primaryLeague} League` : 'No League'}
+            </span>
+          </div>
+          
+          <button 
+            onClick={logout} 
+            className="ml-2 text-xs text-red-500 hover:text-red-700"
+          >
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/providers/discord-provider.tsx
+++ b/src/components/providers/discord-provider.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { FC, PropsWithChildren } from 'react';
+import { DiscordAuthProvider } from '@/hooks/useDiscordAuth';
+
+const DiscordProvider: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <DiscordAuthProvider>
+      {children}
+    </DiscordAuthProvider>
+  );
+};
+
+export default DiscordProvider;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,26 +1,32 @@
 // src/env.d.ts
+
+// TypeScript에서 환경 변수에 대한 타입 정의
 declare namespace NodeJS {
   interface ProcessEnv {
-    NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: string;
+    // API 키
+    OPENAI_API_KEY?: string;
+    
+    // Discord 관련 설정
+    DISCORD_CLIENT_ID?: string;
+    DISCORD_CLIENT_SECRET?: string;
+    DISCORD_REDIRECT_URI?: string;
+    DISCORD_GUILD_ID?: string;
+    
+    // 프론트엔드 환경 변수 (클라이언트에서 접근 가능)
+    NEXT_PUBLIC_DISCORD_CLIENT_ID?: string;
+    NEXT_PUBLIC_DISCORD_REDIRECT_URI?: string;
+    
+    // Vercel KV 관련 설정
+    KV_URL?: string;
+    KV_REST_API_TOKEN?: string;
+    KV_REST_API_READ_ONLY_TOKEN?: string;
+    KV_REST_API_URL?: string;
+    REDIS_URL?: string;
+    
+    // 개발 환경 설정
+    NEXT_PUBLIC_USE_DEV_AUTH?: string;
+    
+    // Vercel 배포 URL
+    VERCEL_URL?: string;
   }
-}
-
-// window 타입 확장
-interface Window {
-  ethereum?: {
-    isMetaMask?: boolean;
-    isCoinbaseWallet?: boolean;
-    providers?: any[];
-    selectedAddress?: string | null;
-    networkVersion?: string;
-    chainId?: string;
-    request?: (args: { method: string; params?: any[] }) => Promise<any>;
-    on: (event: string, callback: (...args: any[]) => void) => void;
-    removeListener: (event: string, callback: (...args: any[]) => void) => void;
-    _metamask?: {
-      isUnlocked?: () => Promise<boolean>;
-    };
-  };
-  // 이전 버전의 MetaMask/지갑 호환성을 위한 확장
-  web3?: any;
 }

--- a/src/hooks/useDiscordAuth.tsx
+++ b/src/hooks/useDiscordAuth.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useEffect, createContext, useContext } from 'react';
+
+interface DiscordUser {
+  id: string;
+  username: string;
+  discriminator: string;
+  avatar: string;
+  roles: string[];
+  primaryLeague?: string;
+  leagues?: string[];
+}
+
+interface DiscordAuthContextType {
+  user: DiscordUser | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  login: () => void;
+  logout: () => void;
+  refreshRoles: () => Promise<void>;
+}
+
+// Discord authentication related constants
+const DISCORD_CLIENT_ID = process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID;
+const DISCORD_REDIRECT_URI = process.env.NEXT_PUBLIC_DISCORD_REDIRECT_URI || `${window?.location?.origin}/auth/callback`;
+const AUTH_STORAGE_KEY = 'text-battle-discord-auth';
+
+// Create context for Discord authentication
+const DiscordAuthContext = createContext<DiscordAuthContextType>({
+  user: null,
+  isConnected: false,
+  isConnecting: false,
+  error: null,
+  login: () => {},
+  logout: () => {},
+  refreshRoles: async () => {},
+});
+
+// Function to retrieve Discord authentication URL
+const getDiscordAuthUrl = () => {
+  if (!DISCORD_CLIENT_ID) {
+    console.error('Discord client ID is not defined');
+    return '';
+  }
+
+  const scope = 'identify guilds guilds.members.read';
+  return `https://discord.com/api/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&redirect_uri=${encodeURIComponent(DISCORD_REDIRECT_URI)}&response_type=code&scope=${encodeURIComponent(scope)}`;
+};
+
+// Provider component for Discord authentication
+export function DiscordAuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<DiscordUser | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check for existing authentication on mount
+  useEffect(() => {
+    const checkAuth = () => {
+      try {
+        const authData = localStorage.getItem(AUTH_STORAGE_KEY);
+        if (authData) {
+          const userData = JSON.parse(authData) as DiscordUser;
+          setUser(userData);
+          setIsConnected(true);
+        }
+      } catch (err) {
+        console.error('Error checking authentication:', err);
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+      }
+    };
+
+    checkAuth();
+  }, []);
+
+  // Redirect to Discord OAuth
+  const login = () => {
+    setIsConnecting(true);
+    setError(null);
+    
+    const authUrl = getDiscordAuthUrl();
+    if (!authUrl) {
+      setError('Discord authentication is not properly configured');
+      setIsConnecting(false);
+      return;
+    }
+    
+    window.location.href = authUrl;
+  };
+
+  // Logout user
+  const logout = () => {
+    setUser(null);
+    setIsConnected(false);
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+  };
+
+  // Refresh user's Discord roles
+  const refreshRoles = async () => {
+    if (!user || !user.id) return;
+    
+    try {
+      setIsConnecting(true);
+      setError(null);
+      
+      // Call API endpoint to refresh roles
+      const response = await fetch('/api/discord/refresh-roles', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ userId: user.id }),
+      });
+      
+      if (!response.ok) {
+        throw new Error('Failed to refresh Discord roles');
+      }
+      
+      const updatedUser = await response.json();
+      
+      // Update user data with new roles
+      setUser(updatedUser);
+      localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(updatedUser));
+      
+    } catch (err) {
+      console.error('Error refreshing roles:', err);
+      setError(err instanceof Error ? err.message : 'Failed to refresh Discord roles');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const value: DiscordAuthContextType = {
+    user,
+    isConnected,
+    isConnecting,
+    error,
+    login,
+    logout,
+    refreshRoles,
+  };
+
+  return (
+    <DiscordAuthContext.Provider value={value}>
+      {children}
+    </DiscordAuthContext.Provider>
+  );
+}
+
+// Hook to use Discord authentication
+export function useDiscordAuth() {
+  return useContext(DiscordAuthContext);
+}


### PR DESCRIPTION
## 변경 내용

기존의 Web3 지갑 연결 방식에서 Discord 계정 연동 방식으로 변경하였습니다.

### 주요 변경사항

1. Web3 지갑 연결 코드 제거
   - 관련 컴포넌트 및 프로바이더 제거

2. Discord OAuth2 인증 구현
   - Discord API를 통한 사용자 인증
   - Discord 서버 역할(role) 기반 리그 시스템

3. 인증 플로우 개선
   - 사용자 경험 개선을 위한 상태 관리 추가
   - Discord 연결 프로세스 최적화
   - 사용자 역할 갱신 기능 추가

### 새로 추가된 파일들

- `src/components/DiscordLoginButton.tsx`: Discord 로그인 버튼 컴포넌트
- `src/hooks/useDiscordAuth.tsx`: Discord 인증 상태 관리 훅
- `src/components/providers/discord-provider.tsx`: Discord 인증 프로바이더
- `src/app/auth/callback/page.tsx`: Discord OAuth 콜백 핸들러
- `src/app/api/discord/auth/route.ts`: Discord 인증 API 엔드포인트
- `src/app/api/discord/refresh-roles/route.ts`: Discord 역할 갱신 API 엔드포인트

### 수정된 파일들

- `src/app/layout.tsx`: 지갑 프로바이더 대신 Discord 프로바이더 사용
- `src/app/page.tsx`: 지갑 연결 버튼 대신 Discord 로그인 버튼 사용
- `src/env.d.ts`: Discord 인증 관련 환경 변수 타입 추가

### 환경 변수 설정

실행을 위해 다음 환경 변수 설정이 필요합니다:

```
# Discord OAuth2 설정
DISCORD_CLIENT_ID=Discord클라이언트ID
DISCORD_CLIENT_SECRET=Discord클라이언트시크릿
DISCORD_REDIRECT_URI=콜백URL (기본: 현재 호스트/auth/callback)
DISCORD_GUILD_ID=Discord서버ID

# 프론트엔드 환경 변수
NEXT_PUBLIC_DISCORD_CLIENT_ID=Discord클라이언트ID
NEXT_PUBLIC_DISCORD_REDIRECT_URI=콜백URL (기본: 현재 호스트/auth/callback)
```

### 테스트 방법

1. Discord Developer Portal에서 애플리케이션 생성 및 설정 구성
2. 필요한 환경 변수 설정
3. 개발 서버 실행
4. Discord 로그인 버튼으로 인증 테스트
5. 역할 기반 리그 시스템 확인