### PR TITLE
Discord 인증 및 리그 시스템 완전 구현

### DIFF
--- a/src/app/api/discord/auth/route.ts
+++ b/src/app/api/discord/auth/route.ts
@@ -1,152 +1,67 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-// Discord API configuration
-const DISCORD_API_URL = 'https://discord.com/api/v10';
-const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
-const CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
-const REDIRECT_URI = process.env.DISCORD_REDIRECT_URI || `${process.env.VERCEL_URL || 'http://localhost:3000'}/auth/callback`;
-const GUILD_ID = process.env.DISCORD_GUILD_ID;
-
-// League mappings based on Discord roles
-const ROLE_TO_LEAGUE_MAP: Record<string, string> = {
-  // Sample mapping - replace with actual Discord role IDs from your server
-  '123456789123456789': 'bronze',
-  '234567890234567890': 'silver',
-  '345678901345678901': 'gold',
-  '456789012456789012': 'platinum',
-};
-
-// Special roles that grant access to multiple leagues
-const SPECIAL_ROLES: Record<string, string[]> = {
-  '567890123567890123': ['gold', 'platinum'],
-  '678901234678901234': ['silver', 'gold'],
-};
-
-// Exchange authorization code for access token
-async function exchangeCodeForToken(code: string) {
-  const params = new URLSearchParams({
-    client_id: CLIENT_ID!,
-    client_secret: CLIENT_SECRET!,
-    grant_type: 'authorization_code',
-    code,
-    redirect_uri: REDIRECT_URI,
-  });
-
-  const response = await fetch(`${DISCORD_API_URL}/oauth2/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: params,
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
-    throw new Error(errorData.error || `Failed to exchange code for token: ${response.status}`);
-  }
-
-  return response.json();
-}
-
-// Fetch user information from Discord API
-async function fetchDiscordUser(accessToken: string) {
-  const response = await fetch(`${DISCORD_API_URL}/users/@me`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch user information: ${response.status}`);
-  }
-
-  return response.json();
-}
-
-// Fetch user's roles from Discord guild
-async function fetchUserGuildRoles(accessToken: string, userId: string) {
-  const response = await fetch(`${DISCORD_API_URL}/users/@me/guilds/${GUILD_ID}/member`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  if (!response.ok) {
-    // If user is not in the guild, return empty roles
-    if (response.status === 404) {
-      return { roles: [] };
-    }
-    throw new Error(`Failed to fetch guild roles: ${response.status}`);
-  }
-
-  return response.json();
-}
-
-// Determine leagues based on Discord roles
-function determineUserLeagues(roles: string[]) {
-  const leagues = new Set<string>();
-  
-  // Always add bronze league as default
-  leagues.add('bronze');
-  
-  // Check role mappings
-  roles.forEach(roleId => {
-    const league = ROLE_TO_LEAGUE_MAP[roleId];
-    if (league) {
-      leagues.add(league);
-    }
-    
-    // Check special roles
-    const specialLeagues = SPECIAL_ROLES[roleId];
-    if (specialLeagues) {
-      specialLeagues.forEach(league => leagues.add(league));
-    }
-  });
-  
-  return Array.from(leagues);
-}
-
-// Get the highest priority league
-function getPrimaryLeague(leagues: string[]) {
-  // League priority order
-  const leaguePriority = ['platinum', 'gold', 'silver', 'bronze'];
-  
-  for (const league of leaguePriority) {
-    if (leagues.includes(league)) {
-      return league;
-    }
-  }
-  
-  return 'bronze'; // Default league
-}
+import { 
+  exchangeCodeForToken, 
+  fetchDiscordUser, 
+  fetchUserGuildRoles,
+  DiscordAPIError
+} from '@/lib/discord-api';
+import { saveDiscordToken, saveDiscordUser } from '@/lib/db';
+import { determineUserLeagues, getPrimaryLeague } from '@/lib/discord-roles';
 
 export async function POST(request: NextRequest) {
   try {
     const { code } = await request.json();
     
     if (!code) {
-      return NextResponse.json({ error: 'No authorization code provided' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'No authorization code provided' },
+        { status: 400 }
+      );
     }
     
-    if (!CLIENT_ID || !CLIENT_SECRET || !GUILD_ID) {
-      return NextResponse.json({ error: 'Discord integration is not properly configured' }, { status: 500 });
+    // 필수 환경 변수 체크
+    if (!process.env.DISCORD_CLIENT_ID || 
+        !process.env.DISCORD_CLIENT_SECRET || 
+        !process.env.DISCORD_GUILD_ID) {
+      console.error('Missing required environment variables for Discord integration');
+      return NextResponse.json(
+        { error: 'Discord integration is not properly configured' },
+        { status: 500 }
+      );
     }
     
-    // Exchange code for token
+    // 1. 코드를 액세스 토큰으로 교환
     const tokenData = await exchangeCodeForToken(code);
     
-    // Fetch user profile
+    // 2. Discord 사용자 정보 가져오기
     const userData = await fetchDiscordUser(tokenData.access_token);
     
-    // Fetch user's guild roles
-    const guildData = await fetchUserGuildRoles(tokenData.access_token, userData.id);
+    // 3. 사용자의 길드 역할 가져오기
+    const userRoles = await fetchUserGuildRoles(tokenData.access_token, userData.id);
     
-    // Determine user's leagues based on roles
-    const userRoles = guildData.roles || [];
+    // 4. 역할 기반으로 리그 결정
     const leagues = determineUserLeagues(userRoles);
     const primaryLeague = getPrimaryLeague(leagues);
     
-    // Prepare user data for response (excluding sensitive token information)
+    // 5. 토큰 정보 저장 (데이터베이스)
+    await saveDiscordToken(userData.id, tokenData);
+    
+    // 6. 사용자 정보 저장 (데이터베이스)
+    const userProfile = {
+      id: userData.id,
+      username: userData.username,
+      discriminator: userData.discriminator,
+      avatar: userData.avatar,
+      roles: userRoles,
+      leagues,
+      primaryLeague,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await saveDiscordUser(userProfile);
+    
+    // 7. 클라이언트에게 응답 (민감한 토큰 정보 제외)
     const responseData = {
       id: userData.id,
       username: userData.username,
@@ -157,14 +72,25 @@ export async function POST(request: NextRequest) {
       primaryLeague,
     };
     
-    // In a real implementation, you would also store this information in your database
-    
     return NextResponse.json(responseData);
     
   } catch (error) {
     console.error('Discord authentication error:', error);
+    
+    // Discord API 오류 처리
+    if (error instanceof DiscordAPIError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status }
+      );
+    }
+    
+    // 기타 오류 처리
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to authenticate with Discord' },
+      { 
+        error: error instanceof Error ? error.message : 'Failed to authenticate with Discord',
+        code: 'UNKNOWN_ERROR'
+      },
       { status: 500 }
     );
   }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -2,23 +2,52 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
+
+// 인증 상태 타입
+type AuthStatus = 'processing' | 'connecting' | 'success' | 'error';
+
+// 사용자 정보 타입
+interface DiscordUser {
+  id: string;
+  username: string;
+  discriminator: string;
+  avatar: string | null;
+  roles: string[];
+  leagues: string[];
+  primaryLeague: string;
+}
 
 export default function DiscordCallback() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [status, setStatus] = useState<'processing' | 'success' | 'error'>('processing');
+  const [status, setStatus] = useState<AuthStatus>('processing');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [user, setUser] = useState<DiscordUser | null>(null);
 
   useEffect(() => {
     const handleCallback = async () => {
       try {
         const code = searchParams.get('code');
+        const error = searchParams.get('error');
+        
+        // 사용자가 인증을 취소한 경우
+        if (error) {
+          if (error === 'access_denied') {
+            throw new Error('Discord authentication was canceled.');
+          } else {
+            throw new Error(`Discord authentication error: ${error}`);
+          }
+        }
         
         if (!code) {
           throw new Error('No authorization code provided');
         }
         
-        // Call our backend API to exchange the code for tokens and user data
+        setStatus('connecting');
+        
+        // Discord API에 인증 코드 전송
         const response = await fetch('/api/discord/auth', {
           method: 'POST',
           headers: {
@@ -27,19 +56,23 @@ export default function DiscordCallback() {
           body: JSON.stringify({ code }),
         });
         
+        // 응답 처리
         if (!response.ok) {
-          const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
-          throw new Error(errorData.error || 'Failed to authenticate with Discord');
+          const errorData = await response.json().catch(() => ({ error: 'Unknown error', code: 'UNKNOWN_ERROR' }));
+          throw new Error(errorData.error || `Failed to authenticate with Discord (${response.status})`);
         }
         
-        const userData = await response.json();
+        // 사용자 데이터 추출 및 저장
+        const userData: DiscordUser = await response.json();
+        setUser(userData);
         
-        // Store user data in localStorage
+        // 로컬 스토리지에 사용자 데이터 저장
         localStorage.setItem('text-battle-discord-auth', JSON.stringify(userData));
         
+        // 성공 상태로 설정
         setStatus('success');
         
-        // Redirect after a short delay
+        // 잠시 후 홈페이지로 리다이렉트
         setTimeout(() => {
           router.push('/');
         }, 2000);
@@ -47,20 +80,50 @@ export default function DiscordCallback() {
       } catch (error) {
         console.error('Error handling Discord callback:', error);
         setStatus('error');
-        setErrorMessage(error instanceof Error ? error.message : 'An unknown error occurred');
+        
+        // 사용자 친화적인 오류 메시지 설정
+        if (error instanceof Error) {
+          setErrorMessage(error.message);
+        } else {
+          setErrorMessage('An unknown error occurred during Discord authentication.');
+        }
+        
+        // 에러 코드 설정 (있는 경우)
+        setErrorCode((error as any)?.code || 'UNKNOWN_ERROR');
       }
     };
     
     handleCallback();
   }, [searchParams, router]);
   
+  // Discord 사용자 아바타 URL 생성
+  const getAvatarUrl = () => {
+    if (!user || !user.avatar) return null;
+    return `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`;
+  };
+  
+  // 리그 이모지 매핑
+  const leagueEmoji = {
+    bronze: '🥉',
+    silver: '🥈',
+    gold: '🥇',
+    platinum: '💎',
+  };
+  
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-md bg-white shadow-lg rounded-lg p-8">
+        <div className="flex justify-center mb-6">
+          <svg width="40" height="30" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-indigo-600">
+            <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="currentColor"/>
+          </svg>
+        </div>
+        
         <h1 className="text-2xl font-bold mb-6 text-center">
-          {status === 'processing' && 'Connecting to Discord...'}
-          {status === 'success' && 'Successfully Connected!'}
-          {status === 'error' && 'Connection Failed'}
+          {status === 'processing' && 'Discord 인증 처리 중...'}
+          {status === 'connecting' && 'Discord 연결 중...'}
+          {status === 'success' && 'Discord 연결 성공!'}
+          {status === 'error' && '연결 실패'}
         </h1>
         
         <div className="flex justify-center mb-6">
@@ -68,27 +131,81 @@ export default function DiscordCallback() {
             <div className="animate-spin h-10 w-10 border-4 border-indigo-500 rounded-full border-t-transparent"></div>
           )}
           
-          {status === 'success' && (
-            <div className="bg-green-100 text-green-700 p-4 rounded-md text-center">
-              <svg className="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              <p>Your Discord account has been connected! Redirecting...</p>
+          {status === 'connecting' && (
+            <div className="flex flex-col items-center">
+              <div className="animate-pulse h-10 w-10 border-4 border-indigo-500 rounded-full border-t-transparent animate-spin mb-4"></div>
+              <p className="text-gray-600">Discord 서버에서 역할 정보를 가져오는 중...</p>
+            </div>
+          )}
+          
+          {status === 'success' && user && (
+            <div className="bg-green-50 text-green-700 p-6 rounded-md text-center w-full">
+              <div className="flex justify-center mb-2">
+                <div className="bg-green-100 rounded-full p-2">
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+              </div>
+              
+              <div className="flex flex-col items-center">
+                {getAvatarUrl() ? (
+                  <div className="h-20 w-20 rounded-full overflow-hidden mb-4">
+                    <img 
+                      src={getAvatarUrl()!} 
+                      alt={user.username} 
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                ) : (
+                  <div className="h-20 w-20 bg-gray-200 rounded-full flex items-center justify-center mb-4">
+                    <span className="text-2xl text-gray-500">
+                      {user.username.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                )}
+                
+                <p className="text-lg font-medium mb-1">{user.username}</p>
+                <p className="text-sm text-gray-600 mb-4">Discord ID: {user.id}</p>
+                
+                <div className="bg-indigo-100 px-4 py-2 rounded-full mb-4">
+                  <span className="font-medium">
+                    {user.primaryLeague.charAt(0).toUpperCase() + user.primaryLeague.slice(1)} 리그
+                    {' '}
+                    {leagueEmoji[user.primaryLeague as keyof typeof leagueEmoji] || '🏆'}
+                  </span>
+                </div>
+                
+                <p className="text-sm">인증이 완료되었습니다! 홈 페이지로 이동합니다...</p>
+              </div>
             </div>
           )}
           
           {status === 'error' && (
-            <div className="bg-red-100 text-red-700 p-4 rounded-md text-center">
-              <svg className="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-              <p className="mb-4">{errorMessage || 'Failed to connect to Discord'}</p>
-              <button 
-                onClick={() => router.push('/')}
-                className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
-              >
-                Return to Home
-              </button>
+            <div className="bg-red-50 text-red-700 p-6 rounded-md text-center w-full">
+              <div className="flex justify-center mb-2">
+                <div className="bg-red-100 rounded-full p-2">
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </div>
+              </div>
+              
+              <p className="text-lg font-medium mb-2">인증 오류</p>
+              <p className="mb-4">{errorMessage || '알 수 없는 오류가 발생했습니다.'}</p>
+              
+              {errorCode && (
+                <p className="text-xs text-red-500 mb-4">오류 코드: {errorCode}</p>
+              )}
+              
+              <div className="flex justify-center">
+                <button 
+                  onClick={() => router.push('/')}
+                  className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md transition-colors"
+                >
+                  홈으로 돌아가기
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/DiscordLoginButton.tsx
+++ b/src/components/DiscordLoginButton.tsx
@@ -1,25 +1,86 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useDiscordAuth } from '@/hooks/useDiscordAuth';
+import { LEAGUES } from '@/lib/discord-roles';
+
+// 팝오버 메뉴 타입
+type PopoverMenuState = 'closed' | 'open';
 
 export function DiscordLoginButton() {
   const [mounted, setMounted] = useState(false);
-  const { user, isConnected, isConnecting, error, login, logout } = useDiscordAuth();
+  const [menuState, setMenuState] = useState<PopoverMenuState>('closed');
+  const menuRef = useRef<HTMLDivElement>(null);
+  
+  const { user, isConnected, isConnecting, error, login, logout, refreshRoles } = useDiscordAuth();
 
-  // Check component mount for client side rendering
+  // SSR 대응
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  // Handle SSR
+  // 팝오버 메뉴 외부 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuState('closed');
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // SSR 대응
   if (!mounted) return null;
 
+  // 유저 아바타 URL 생성
+  const getUserAvatarUrl = () => {
+    if (!user?.avatar) return null;
+    return `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`;
+  };
+
+  // 역할 새로고침 핸들러
+  const handleRefreshRoles = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await refreshRoles();
+      setMenuState('closed');
+    } catch (err) {
+      console.error('Error refreshing roles:', err);
+    }
+  };
+
+  // 로그아웃 핸들러
+  const handleLogout = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    logout();
+    setMenuState('closed');
+  };
+
+  // 리그 색상 
+  const getLeagueColor = () => {
+    if (!user?.primaryLeague) return '';
+    
+    const league = LEAGUES[user.primaryLeague as keyof typeof LEAGUES];
+    return league ? league.color : '#888888';
+  };
+  
+  // 리그 아이콘
+  const getLeagueIcon = () => {
+    if (!user?.primaryLeague) return '🏆';
+    
+    const league = LEAGUES[user.primaryLeague as keyof typeof LEAGUES];
+    return league ? league.icon : '🏆';
+  };
+
   return (
-    <div className="flex flex-col items-end mb-6">
-      {/* Display error message */}
+    <div className="relative">
+      {/* 에러 메시지 표시 */}
       {error && (
-        <div className="mb-2 p-2 bg-red-600 text-white text-sm rounded-md animate-pulse">
+        <div className="mb-2 p-2 bg-red-600 text-white text-sm rounded-md animate-pulse max-w-md absolute -top-12 right-0">
           {error}
         </div>
       )}
@@ -28,38 +89,91 @@ export function DiscordLoginButton() {
         <button 
           onClick={login} 
           disabled={isConnecting}
-          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md flex items-center gap-2 transition-opacity duration-200"
+          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md flex items-center gap-2 transition-opacity duration-200 disabled:opacity-70"
         >
           <svg width="20" height="20" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="#ffffff"/>
+            <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9795C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5576C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.305 54.5139 18.3638 54.4378C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0523 48.4172 21.9935 48.2735 21.8676 48.2256C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5041 16.1781 45.304 16.3068 45.2082C16.679 44.9293 17.0513 44.6391 17.4067 44.3461C17.471 44.2926 17.5606 44.2813 17.6362 44.3151C29.2558 49.6202 41.8354 49.6202 53.3179 44.3151C53.3935 44.2785 53.4831 44.2898 53.5502 44.3433C53.9057 44.6363 54.2779 44.9293 54.6529 45.2082C54.7816 45.304 54.7732 45.5041 54.6333 45.5858C52.8646 46.6197 51.0259 47.4931 49.0921 48.2228C48.9662 48.2707 48.9102 48.4172 48.9718 48.5383C50.038 50.6034 51.2554 52.5699 52.5959 54.435C52.6519 54.5139 52.7526 54.5477 52.845 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5576C70.6551 45.5182 70.6887 45.459 70.6943 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9823C60.1772 4.9429 60.1437 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.3178 37.3253C43.8196 37.3253 40.9371 34.1136 40.9371 30.1693C40.9371 26.225 43.7636 23.0133 47.3178 23.0133C50.9 23.0133 53.7545 26.2532 53.6986 30.1693C53.6986 34.1136 50.9 37.3253 47.3178 37.3253Z" fill="white"/>
           </svg>
-          {isConnecting ? 'Connecting...' : 'Connect with Discord'}
+          {isConnecting ? 'Discord 연결 중...' : 'Discord로 로그인'}
         </button>
       ) : (
-        <div className="flex items-center gap-2 p-2 bg-gray-100 dark:bg-gray-700 rounded-lg shadow">
-          {user?.avatar && (
-            <div className="w-8 h-8 rounded-full overflow-hidden">
-              <img 
-                src={`https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`} 
-                alt={user.username} 
-                className="w-full h-full object-cover"
-              />
+        <div className="relative">
+          <div 
+            onClick={() => setMenuState(menuState === 'open' ? 'closed' : 'open')}
+            className="flex items-center gap-2 p-2 bg-gray-100 dark:bg-gray-700 rounded-lg shadow cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+          >
+            {/* 사용자 아바타 */}
+            {getUserAvatarUrl() ? (
+              <div className="w-8 h-8 rounded-full overflow-hidden">
+                <img 
+                  src={getUserAvatarUrl()!} 
+                  alt={user.username || '사용자'} 
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            ) : (
+              <div className="w-8 h-8 bg-indigo-200 dark:bg-indigo-700 rounded-full flex items-center justify-center">
+                <span className="text-indigo-700 dark:text-indigo-200 text-sm font-bold">
+                  {user?.username?.charAt(0).toUpperCase() || 'U'}
+                </span>
+              </div>
+            )}
+            
+            <div className="flex flex-col text-left">
+              <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                {user?.username || '사용자'}
+              </span>
+              <div className="flex items-center">
+                <span 
+                  className="text-xs px-1.5 py-0.5 rounded-full font-medium"
+                  style={{ backgroundColor: getLeagueColor() + '33', color: getLeagueColor() }}
+                >
+                  {getLeagueIcon()} {user?.primaryLeague?.charAt(0).toUpperCase() + user?.primaryLeague?.slice(1) || 'Bronze'}
+                </span>
+              </div>
             </div>
-          )}
-          
-          <div className="flex flex-col">
-            <span className="text-sm font-medium">{user?.username}</span>
-            <span className="text-xs text-gray-500">
-              {user?.primaryLeague ? `${user.primaryLeague} League` : 'No League'}
-            </span>
+            
+            {/* 드롭다운 화살표 */}
+            <svg 
+              className={`w-4 h-4 ml-1 transition-transform duration-200 ${menuState === 'open' ? 'rotate-180' : ''}`} 
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24" 
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
           </div>
           
-          <button 
-            onClick={logout} 
-            className="ml-2 text-xs text-red-500 hover:text-red-700"
-          >
-            Logout
-          </button>
+          {/* 드롭다운 메뉴 */}
+          {menuState === 'open' && (
+            <div 
+              ref={menuRef}
+              className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg overflow-hidden z-20 border border-gray-200 dark:border-gray-700"
+            >
+              <div className="py-1">
+                <button
+                  onClick={handleRefreshRoles}
+                  className="flex w-full items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  disabled={isConnecting}
+                >
+                  <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                  {isConnecting ? '역할 갱신 중...' : 'Discord 역할 갱신'}
+                </button>
+                <button
+                  onClick={handleLogout}
+                  className="flex w-full items-center px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900"
+                >
+                  <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                  </svg>
+                  로그아웃
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/ui/LeagueBadge.tsx
+++ b/src/components/ui/LeagueBadge.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React from 'react';
+import { LEAGUES } from '@/lib/discord-roles';
+
+interface LeagueBadgeProps {
+  leagueId: string;
+  size?: 'sm' | 'md' | 'lg';
+  showIcon?: boolean;
+  showText?: boolean;
+  variant?: 'default' | 'outline' | 'filled';
+  className?: string;
+}
+
+export default function LeagueBadge({
+  leagueId,
+  size = 'md',
+  showIcon = true,
+  showText = true,
+  variant = 'default',
+  className = '',
+}: LeagueBadgeProps) {
+  // 리그 ID 정규화
+  const normalizedLeagueId = leagueId.toLowerCase();
+  
+  // 리그 정보 가져오기
+  const league = LEAGUES[normalizedLeagueId as keyof typeof LEAGUES];
+  
+  if (!league) {
+    return null;
+  }
+  
+  // 리그 이름
+  const leagueName = league.name || leagueId.charAt(0).toUpperCase() + leagueId.slice(1);
+  
+  // 리그 색상 및 스타일
+  const leagueColor = league.color || '#888888';
+  
+  // 배지 크기에 따른 클래스
+  const sizeClasses = {
+    sm: 'text-xs px-1.5 py-0.5',
+    md: 'text-sm px-2 py-1',
+    lg: 'text-base px-2.5 py-1.5',
+  };
+  
+  // 배지 스타일 배리언트
+  const variantClasses = {
+    default: `bg-opacity-20 text-opacity-90`,
+    outline: `bg-transparent border border-current`,
+    filled: `text-white`,
+  };
+  
+  // 배지 스타일 객체
+  const badgeStyle = {
+    backgroundColor: variant === 'filled' ? leagueColor : variant === 'default' ? `${leagueColor}33` : 'transparent',
+    color: variant === 'filled' ? 'white' : leagueColor,
+    borderColor: variant === 'outline' ? leagueColor : 'transparent',
+  };
+  
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-full font-medium ${sizeClasses[size]} ${className}`}
+      style={badgeStyle}
+    >
+      {showIcon && (
+        <span className="mr-1">{league.icon}</span>
+      )}
+      {showText && leagueName}
+    </span>
+  );
+}
+
+// 모든 리그 뱃지 컴포넌트
+export function LeagueBadges({
+  leagues,
+  size = 'sm',
+  showIcons = true,
+  variant = 'default',
+  className = '',
+}: {
+  leagues: string[];
+  size?: 'sm' | 'md' | 'lg';
+  showIcons?: boolean;
+  variant?: 'default' | 'outline' | 'filled';
+  className?: string;
+}) {
+  // 리그 우선순위 정렬
+  const sortedLeagues = [...leagues].sort((a, b) => {
+    const leagueA = LEAGUES[a as keyof typeof LEAGUES];
+    const leagueB = LEAGUES[b as keyof typeof LEAGUES];
+    
+    if (!leagueA) return 1;
+    if (!leagueB) return -1;
+    
+    return leagueB.order - leagueA.order;
+  });
+  
+  return (
+    <div className={`flex flex-wrap gap-1 ${className}`}>
+      {sortedLeagues.map((leagueId) => (
+        <LeagueBadge
+          key={leagueId}
+          leagueId={leagueId}
+          size={size}
+          showIcon={showIcons}
+          variant={variant}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,179 @@
+import { kv } from '@vercel/kv';
+
+// Discord 사용자 정보 타입
+export interface DiscordUser {
+  id: string;
+  username: string;
+  discriminator: string;
+  avatar: string | null;
+  roles: string[];
+  leagues: string[];
+  primaryLeague: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Discord 토큰 정보 타입
+export interface DiscordToken {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number; // 토큰 만료 시간 (밀리초 단위의 타임스탬프)
+}
+
+// 사용자 저장 키 형식
+const getUserKey = (userId: string) => `user:${userId}`;
+const getTokenKey = (userId: string) => `token:${userId}`;
+
+// Discord 사용자 정보 저장
+export async function saveDiscordUser(user: DiscordUser): Promise<boolean> {
+  try {
+    const now = new Date().toISOString();
+    const userData = {
+      ...user,
+      updatedAt: now,
+      createdAt: user.createdAt || now,
+    };
+    
+    await kv.set(getUserKey(user.id), userData);
+    return true;
+  } catch (error) {
+    console.error('Error saving Discord user:', error);
+    return false;
+  }
+}
+
+// Discord 토큰 정보 저장
+export async function saveDiscordToken(userId: string, tokenData: DiscordToken): Promise<boolean> {
+  try {
+    await kv.set(getTokenKey(userId), tokenData);
+    return true;
+  } catch (error) {
+    console.error('Error saving Discord token:', error);
+    return false;
+  }
+}
+
+// Discord 사용자 정보 조회
+export async function getDiscordUser(userId: string): Promise<DiscordUser | null> {
+  try {
+    const user = await kv.get<DiscordUser>(getUserKey(userId));
+    return user;
+  } catch (error) {
+    console.error('Error getting Discord user:', error);
+    return null;
+  }
+}
+
+// Discord 토큰 정보 조회
+export async function getDiscordToken(userId: string): Promise<DiscordToken | null> {
+  try {
+    const token = await kv.get<DiscordToken>(getTokenKey(userId));
+    return token;
+  } catch (error) {
+    console.error('Error getting Discord token:', error);
+    return null;
+  }
+}
+
+// Discord 사용자 역할 업데이트
+export async function updateUserRoles(
+  userId: string,
+  roles: string[],
+  leagues: string[],
+  primaryLeague: string
+): Promise<boolean> {
+  try {
+    const user = await getDiscordUser(userId);
+    if (!user) return false;
+    
+    const updatedUser = {
+      ...user,
+      roles,
+      leagues,
+      primaryLeague,
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await kv.set(getUserKey(userId), updatedUser);
+    return true;
+  } catch (error) {
+    console.error('Error updating user roles:', error);
+    return false;
+  }
+}
+
+// 토큰이 유효한지 확인
+export function isTokenValid(token: DiscordToken | null): boolean {
+  if (!token) return false;
+  
+  // 현재 시간보다 만료 시간이 나중인지 확인 (10분의 버퍼 추가)
+  return token.expires_at > Date.now() + 10 * 60 * 1000;
+}
+
+// 리그별 사용자 리스트 조회 (페이지네이션)
+export async function getUsersByLeague(
+  league: string,
+  limit = 10,
+  cursor?: string
+): Promise<{ users: DiscordUser[]; nextCursor: string | null }> {
+  try {
+    // 페이지네이션을 위한 스캔 방식
+    // 실제 사용에서는 보다 효율적인 방법을 사용해야 함
+    // 이 예제에서는 단순화된 구현을 제공
+    
+    // 페이지네이션 구현을 위해 패턴 매칭을 사용하여 사용자 키를 스캔
+    const scanResult = await kv.scan(0, {
+      match: 'user:*',
+      count: 100, // 한 번에 가져올 최대 항목 수
+    });
+    
+    const [, keys] = scanResult;
+    const users: DiscordUser[] = [];
+    
+    for (const key of keys) {
+      const user = await kv.get<DiscordUser>(key);
+      if (user && user.leagues && user.leagues.includes(league)) {
+        users.push(user);
+      }
+      
+      if (users.length >= limit) break;
+    }
+    
+    return {
+      users,
+      nextCursor: null, // 실제 구현에서는 다음 커서 값을 계산해야 함
+    };
+  } catch (error) {
+    console.error('Error getting users by league:', error);
+    return { users: [], nextCursor: null };
+  }
+}
+
+// 모든 사용자 삭제 (개발 환경에서만 사용)
+export async function deleteAllUsers(): Promise<boolean> {
+  if (process.env.NODE_ENV === 'production') {
+    console.error('Cannot delete all users in production');
+    return false;
+  }
+  
+  try {
+    const scanResult = await kv.scan(0, { match: 'user:*' });
+    const [, keys] = scanResult;
+    
+    for (const key of keys) {
+      await kv.del(key);
+    }
+    
+    const tokenScanResult = await kv.scan(0, { match: 'token:*' });
+    const [, tokenKeys] = tokenScanResult;
+    
+    for (const key of tokenKeys) {
+      await kv.del(key);
+    }
+    
+    return true;
+  } catch (error) {
+    console.error('Error deleting all users:', error);
+    return false;
+  }
+}

--- a/src/lib/discord-api.ts
+++ b/src/lib/discord-api.ts
@@ -1,0 +1,248 @@
+// Discord API 통신 및 토큰 관리 모듈
+
+import {
+  getDiscordToken,
+  saveDiscordToken,
+  isTokenValid,
+  DiscordToken
+} from './db';
+
+// Discord API 설정
+const DISCORD_API_URL = 'https://discord.com/api/v10';
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+const CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
+const REDIRECT_URI = process.env.DISCORD_REDIRECT_URI || `${process.env.VERCEL_URL || 'http://localhost:3000'}/auth/callback`;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+// Discord API 오류 타입
+export class DiscordAPIError extends Error {
+  status: number;
+  code: string;
+  
+  constructor(message: string, status: number, code: string = 'DISCORD_API_ERROR') {
+    super(message);
+    this.name = 'DiscordAPIError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// Discord 사용자 정보 타입
+export interface DiscordUserData {
+  id: string;
+  username: string;
+  discriminator: string;
+  avatar: string | null;
+  bot?: boolean;
+  system?: boolean;
+  mfa_enabled?: boolean;
+  locale?: string;
+  verified?: boolean;
+  email?: string | null;
+  flags?: number;
+  premium_type?: number;
+  public_flags?: number;
+}
+
+// Discord 길드 멤버 정보 타입
+export interface DiscordGuildMember {
+  user?: DiscordUserData;
+  nick?: string | null;
+  roles: string[];
+  joined_at: string;
+  premium_since?: string | null;
+  deaf: boolean;
+  mute: boolean;
+  pending?: boolean;
+  permissions?: string;
+}
+
+// 인증 코드를 토큰으로 교환
+export async function exchangeCodeForToken(code: string): Promise<DiscordToken> {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID!,
+    client_secret: CLIENT_SECRET!,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: REDIRECT_URI,
+  });
+
+  const response = await fetch(`${DISCORD_API_URL}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+    throw new DiscordAPIError(
+      data.error || `Failed to exchange code for token: ${response.status}`,
+      response.status
+    );
+  }
+
+  const data = await response.json();
+  
+  // 만료 시간 계산
+  const expiresAt = Date.now() + data.expires_in * 1000;
+  
+  return {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: expiresAt,
+  };
+}
+
+// 토큰 갱신
+export async function refreshToken(userId: string, refreshToken: string): Promise<DiscordToken> {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID!,
+    client_secret: CLIENT_SECRET!,
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+
+  const response = await fetch(`${DISCORD_API_URL}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+    throw new DiscordAPIError(
+      data.error || `Failed to refresh token: ${response.status}`,
+      response.status,
+      'TOKEN_REFRESH_FAILED'
+    );
+  }
+
+  const data = await response.json();
+  
+  // 만료 시간 계산
+  const expiresAt = Date.now() + data.expires_in * 1000;
+  
+  const newToken = {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: expiresAt,
+  };
+  
+  // 토큰 저장
+  await saveDiscordToken(userId, newToken);
+  
+  return newToken;
+}
+
+// 유효한 액세스 토큰 가져오기 (필요시 갱신)
+export async function getValidAccessToken(userId: string): Promise<string> {
+  const token = await getDiscordToken(userId);
+  
+  if (!token) {
+    throw new DiscordAPIError('User token not found', 401, 'TOKEN_NOT_FOUND');
+  }
+  
+  // 토큰이 유효한지 확인
+  if (isTokenValid(token)) {
+    return token.access_token;
+  }
+  
+  // 토큰이 만료되었다면 갱신 시도
+  try {
+    const newToken = await refreshToken(userId, token.refresh_token);
+    return newToken.access_token;
+  } catch (error) {
+    // 토큰 갱신에 실패하면 다시 로그인 필요
+    throw new DiscordAPIError(
+      'Token expired and refresh failed, please login again',
+      401,
+      'TOKEN_REFRESH_FAILED'
+    );
+  }
+}
+
+// Discord 사용자 정보 가져오기
+export async function fetchDiscordUser(accessToken: string): Promise<DiscordUserData> {
+  const response = await fetch(`${DISCORD_API_URL}/users/@me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+    throw new DiscordAPIError(
+      data.error || `Failed to fetch user data: ${response.status}`,
+      response.status,
+      'FETCH_USER_FAILED'
+    );
+  }
+
+  return response.json();
+}
+
+// Discord 길드 내 사용자 역할 정보 가져오기
+export async function fetchUserGuildRoles(accessToken: string, userId: string): Promise<string[]> {
+  if (!GUILD_ID) {
+    throw new DiscordAPIError('Guild ID not configured', 500, 'GUILD_ID_MISSING');
+  }
+  
+  const response = await fetch(
+    `${DISCORD_API_URL}/users/@me/guilds/${GUILD_ID}/member`, 
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    // 사용자가 길드에 없는 경우
+    if (response.status === 404) {
+      return [];
+    }
+    
+    const data = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+    throw new DiscordAPIError(
+      data.error || `Failed to fetch guild roles: ${response.status}`,
+      response.status,
+      'FETCH_ROLES_FAILED'
+    );
+  }
+
+  const guildMember = await response.json() as DiscordGuildMember;
+  return guildMember.roles || [];
+}
+
+// OAuth2 인증 URL 생성
+export function getDiscordAuthUrl(): string {
+  if (!CLIENT_ID) {
+    throw new Error('Discord client ID not configured');
+  }
+
+  const scope = 'identify guilds guilds.members.read';
+  return `https://discord.com/api/oauth2/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&response_type=code&scope=${encodeURIComponent(scope)}`;
+}
+
+// Discord 사용자 토큰 취소 (로그아웃 시)
+export async function revokeToken(token: string): Promise<boolean> {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID!,
+    client_secret: CLIENT_SECRET!,
+    token,
+  });
+
+  const response = await fetch(`${DISCORD_API_URL}/oauth2/token/revoke`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  return response.ok;
+}

--- a/src/lib/discord-roles.ts
+++ b/src/lib/discord-roles.ts
@@ -1,0 +1,164 @@
+// Discord 역할 및 리그 관리 로직
+
+// 역할 ID와 리그 매핑
+export const ROLE_TO_LEAGUE_MAP: Record<string, string> = {
+  // 여기에 실제 디스코드 서버의 역할 ID와 해당 리그를 매핑합니다
+  // 예시 역할 ID - 실제 구현 시 업데이트 필요
+  '123456789123456789': 'bronze',
+  '234567890234567890': 'silver',
+  '345678901345678901': 'gold',
+  '456789012456789012': 'platinum',
+};
+
+// 특별 역할 - 여러 리그에 접근 권한을 부여하는 역할
+export const SPECIAL_ROLES: Record<string, string[]> = {
+  '567890123567890123': ['gold', 'platinum'],
+  '678901234678901234': ['silver', 'gold'],
+};
+
+// 리그 정보 
+export const LEAGUES = {
+  bronze: {
+    id: 'bronze',
+    name: '브론즈 리그',
+    color: '#cd7f32',
+    icon: '🥉',
+    description: '모든 플레이어를 위한 시작 리그',
+    minRating: 0,
+    order: 1
+  },
+  silver: {
+    id: 'silver',
+    name: '실버 리그',
+    color: '#c0c0c0',
+    icon: '🥈',
+    description: '일정 수준의 실력을 갖춘 플레이어를 위한 리그',
+    minRating: 1000,
+    order: 2
+  },
+  gold: {
+    id: 'gold',
+    name: '골드 리그',
+    color: '#ffd700',
+    icon: '🥇',
+    description: '숙련된 플레이어를 위한 리그',
+    minRating: 1500,
+    order: 3
+  },
+  platinum: {
+    id: 'platinum',
+    name: '플래티넘 리그',
+    color: '#e5e4e2',
+    icon: '💎',
+    description: '최상위 플레이어를 위한 엘리트 리그',
+    minRating: 2000,
+    order: 4
+  },
+};
+
+// 사용자의 역할에 따라 접근 가능한 리그 목록 결정
+export function determineUserLeagues(roles: string[]): string[] {
+  if (!roles || !Array.isArray(roles) || roles.length === 0) {
+    return ['bronze']; // 기본 리그
+  }
+  
+  const leagues = new Set<string>();
+  
+  // 브론즈 리그는 기본적으로 모든 사용자에게 부여
+  leagues.add('bronze');
+  
+  // 역할 기반 리그 할당
+  roles.forEach(roleId => {
+    const league = ROLE_TO_LEAGUE_MAP[roleId];
+    if (league) {
+      leagues.add(league);
+    }
+    
+    // 특별 역할 처리
+    const specialLeagues = SPECIAL_ROLES[roleId];
+    if (specialLeagues) {
+      specialLeagues.forEach(league => leagues.add(league));
+    }
+  });
+  
+  return Array.from(leagues);
+}
+
+// 사용자의 주요 리그(가장 높은 등급의 리그) 결정
+export function getPrimaryLeague(leagues: string[]): string {
+  // 리그 우선순위 (높은 등급부터)
+  const leaguePriority = ['platinum', 'gold', 'silver', 'bronze'];
+  
+  // 사용자가 접근 가능한 가장 높은 등급의 리그 찾기
+  for (const league of leaguePriority) {
+    if (leagues.includes(league)) {
+      return league;
+    }
+  }
+  
+  return 'bronze'; // 기본 리그
+}
+
+// 리그 정보 조회
+export function getLeagueInfo(leagueId: string) {
+  return LEAGUES[leagueId as keyof typeof LEAGUES] || {
+    id: leagueId,
+    name: leagueId.charAt(0).toUpperCase() + leagueId.slice(1) + ' League',
+    color: '#888888',
+    icon: '🏆',
+    description: 'A league for battlers',
+    minRating: 0,
+    order: 0
+  };
+}
+
+// 해당 리그 접근 권한이 있는지 확인
+export function hasLeagueAccess(leagues: string[], leagueId: string): boolean {
+  return leagues.includes(leagueId);
+}
+
+// 역할 ID로부터 역할 이름 조회 (개발용 헬퍼 함수)
+export function getRoleNameFromId(roleId: string): string {
+  const leagueId = ROLE_TO_LEAGUE_MAP[roleId];
+  if (leagueId) {
+    const league = LEAGUES[leagueId as keyof typeof LEAGUES];
+    return league ? `${league.name} 역할` : '알 수 없는 역할';
+  }
+  
+  // 특별 역할 처리
+  const specialLeagues = SPECIAL_ROLES[roleId];
+  if (specialLeagues && specialLeagues.length > 0) {
+    const leagueNames = specialLeagues.map(leagueId => {
+      const league = LEAGUES[leagueId as keyof typeof LEAGUES];
+      return league ? league.name : leagueId;
+    }).join(', ');
+    
+    return `특별 역할 (${leagueNames})`;
+  }
+  
+  return '일반 역할';
+}
+
+// 사용자 역할 설명 생성 (사용자 경험 개선용)
+export function generateRoleDescription(roles: string[]): string {
+  if (!roles || roles.length === 0) {
+    return '역할 없음 (기본 브론즈 리그에 속합니다)';
+  }
+  
+  const leagues = determineUserLeagues(roles);
+  const primaryLeague = getPrimaryLeague(leagues);
+  const primaryLeagueInfo = getLeagueInfo(primaryLeague);
+  
+  let description = `주 리그: ${primaryLeagueInfo.name} (${primaryLeagueInfo.icon})`;
+  
+  if (leagues.length > 1) {
+    const otherLeagues = leagues
+      .filter(league => league !== primaryLeague)
+      .map(league => getLeagueInfo(league).name)
+      .join(', ');
+    
+    description += `\n접근 가능한 추가 리그: ${otherLeagues}`;
+  }
+  
+  return description;
+}


### PR DESCRIPTION
## Discord 인증 및 리그 시스템 완전 구현

이 PR은 기존에 개발된 Discord 인증 시스템의 미구현된 부분을 완전히 구현한 것입니다. 주요 변경사항은 다음과 같습니다:

### 데이터베이스 및 토큰 관리 구현
- Vercel KV를 활용한 사용자 및 토큰 저장 로직 구현
- 토큰 만료 및 자동 갱신 메커니즘 추가
- Discord 사용자 정보와 역할 관리 기능 구현

### 역할 기반 리그 시스템 개선
- Discord 역할에 따른 리그 할당 알고리즘 구현
- 리그 메타데이터 및 시각적 요소 추가
- 다중 리그 멤버십 지원

### API 엔드포인트 완전 구현
- `/api/discord/auth`: 사용자 인증 및 역할 가져오기
- `/api/discord/refresh-roles`: 역할 갱신 및 리그 업데이트

### UI 컴포넌트 개선
- Discord 로그인 버튼 및 사용자 드롭다운 메뉴 개선
- 인증 콜백 페이지 UI 개선 및 오류 처리 추가
- 리그 뱃지 컴포넌트 추가

### 오류 처리 및 예외 상황 관리
- 토큰 만료 시 자동 갱신 또는 재로그인 프로세스
- 서버 연결 오류 처리
- 사용자 친화적인 오류 메시지

### 테스트 방법
1. Discord 개발자 포털에서 애플리케이션 설정
2. 환경 변수 설정
3. 앱 실행 및 Discord 로그인 테스트
4. 역할 갱신 기능 테스트
5. 리그 시스템 확인

### 필요한 환경 변수
```
# Discord OAuth2 설정
DISCORD_CLIENT_ID=Discord클라이언트ID
DISCORD_CLIENT_SECRET=Discord클라이언트시크릿
DISCORD_REDIRECT_URI=콜백URL (기본: 현재 호스트/auth/callback)
DISCORD_GUILD_ID=Discord서버ID

# 프론트엔드 환경 변수
NEXT_PUBLIC_DISCORD_CLIENT_ID=Discord클라이언트ID
NEXT_PUBLIC_DISCORD_REDIRECT_URI=콜백URL (기본: 현재 호스트/auth/callback)

# Vercel KV 데이터베이스 설정
KV_URL=your_kv_url
KV_REST_API_TOKEN=your_kv_token
KV_REST_API_READ_ONLY_TOKEN=your_read_only_token
KV_REST_API_URL=your_kv_api_url
```