### PR TITLE
Add 200 character limit for hero name and 500 character limit for descriptions

### DIFF
--- a/src/components/CharacterDetail.tsx
+++ b/src/components/CharacterDetail.tsx
@@ -6,6 +6,9 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useDiscordAuth } from '@/hooks/useDiscordAuth';
 
+// Constants for input limits (same as in CreateCharacterModal for consistency)
+const TRAITS_MAX_LENGTH = 500;
+
 interface Character {
   id: string;
   name: string;
@@ -263,6 +266,14 @@ export function CharacterDetail({ id }: CharacterDetailProps) {
     }
   };
 
+  // Handle traits input with length limit
+  const handleTraitsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    if (value.length <= TRAITS_MAX_LENGTH) {
+      setNewTraits(value);
+    }
+  };
+
   // Add function to handle traits update
   const updateTraits = async () => {
     if (!user?.id || !character) return;
@@ -358,10 +369,20 @@ export function CharacterDetail({ id }: CharacterDetailProps) {
           
           {isEditingTraits ? (
             <div>
+              <div className="mb-2">
+                <label htmlFor="traits" className="text-sm text-gray-400">
+                  <span className="mr-2">Character limit:</span>
+                  <span className={newTraits.length >= TRAITS_MAX_LENGTH * 0.9 ? "text-yellow-500" : "text-gray-400"}>
+                    {newTraits.length}/{TRAITS_MAX_LENGTH}
+                  </span>
+                </label>
+              </div>
               <textarea
                 ref={textareaRef}
+                id="traits"
                 value={newTraits}
-                onChange={(e) => setNewTraits(e.target.value)}
+                onChange={handleTraitsChange}
+                maxLength={TRAITS_MAX_LENGTH}
                 className="w-full h-40 p-2 bg-gray-700 text-white rounded-md mb-2"
                 placeholder="Enter hero traits..."
               />

--- a/src/components/CreateCharacterModal.tsx
+++ b/src/components/CreateCharacterModal.tsx
@@ -4,6 +4,10 @@ import { useState, useEffect } from 'react';
 import { useDiscordAuth } from '@/hooks/useDiscordAuth';
 import { getLeagueInfo } from '@/lib/discord-roles';
 
+// Constants for input limits
+const NAME_MAX_LENGTH = 200;
+const TRAITS_MAX_LENGTH = 500;
+
 interface CreateCharacterModalProps {
   onClose: () => void;
   onSuccess: () => void;
@@ -65,6 +69,22 @@ export function CreateCharacterModal({
       }
     } catch (error) {
       console.error('Error checking existing characters:', error);
+    }
+  };
+
+  // Handle name input with length limit
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length <= NAME_MAX_LENGTH) {
+      setName(value);
+    }
+  };
+
+  // Handle traits input with length limit
+  const handleTraitsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    if (value.length <= TRAITS_MAX_LENGTH) {
+      setTraits(value);
     }
   };
 
@@ -163,13 +183,14 @@ export function CreateCharacterModal({
           <form onSubmit={handleSubmit}>
             <div className="mb-4">
               <label htmlFor="name" className="block text-sm font-medium mb-1">
-                Hero Name
+                Hero Name <span className="text-gray-400 text-xs">({name.length}/{NAME_MAX_LENGTH})</span>
               </label>
               <input
                 type="text"
                 id="name"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={handleNameChange}
+                maxLength={NAME_MAX_LENGTH}
                 className="w-full bg-gray-700 rounded-md border border-gray-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 placeholder="Enter hero name"
               />
@@ -177,16 +198,22 @@ export function CreateCharacterModal({
 
             <div className="mb-4">
               <label htmlFor="traits" className="block text-sm font-medium mb-1">
-                Hero Descriptions
+                Hero Descriptions <span className="text-gray-400 text-xs">({traits.length}/{TRAITS_MAX_LENGTH})</span>
               </label>
               <textarea
                 id="traits"
                 value={traits}
-                onChange={(e) => setTraits(e.target.value)}
+                onChange={handleTraitsChange}
+                maxLength={TRAITS_MAX_LENGTH}
                 rows={4}
                 className="w-full bg-gray-700 rounded-md border border-gray-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 placeholder="Describe traits, abilities, and personality of your hero"
               />
+              {traits.length >= TRAITS_MAX_LENGTH * 0.9 && (
+                <p className="text-yellow-500 text-xs mt-1">
+                  You're approaching the maximum character limit.
+                </p>
+              )}
             </div>
 
             <div className="mb-6">


### PR DESCRIPTION
## Changes in this Pull Request
This PR adds input character limits to improve UI and data quality:

- **Hero Name**: Maximum 200 characters
- **Hero Descriptions**: Maximum 500 characters

## Features Added:
- Character counters in the create and edit forms
- Visual feedback when approaching character limits
- Proper validation in both creation and editing forms

## Implementation Notes:
- Added constants for maximum length values to make them easily configurable
- Added character counters showing current character count vs maximum
- Added warning when approaching the character limit (at 90% capacity)
- Modified the input handlers to prevent exceeding the limit
- Applied maxLength attribute to inputs for additional browser-level validation
- Ensured character limits apply in both the create and edit forms

## Screenshots
![Character Creation Form](https://i.imgur.com/example.png)
_(Note: Actual screenshots to be added in code review)_

## Testing Done
- Verified character limits work in the creation form
- Verified character limits work in the edit form
- Checked warning displays when approaching limits
- Confirmed form prevents exceeding character limits